### PR TITLE
Fix plugin certs on agent nodes - both plugin.crt and plugin.key need…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ A unique identifier for the API client.
 
 Set to True to install the Flocker Plugin for Docker.
 
+    flocker_docker_plugin_groupname: flocker_agents
+
+The groupname of the nodes that docker plugin will be installed - usually same as agent nodes.
+
 ## Example Playbook
 
     ---

--- a/tasks/configure_plugin.yml
+++ b/tasks/configure_plugin.yml
@@ -6,7 +6,7 @@
     - plugin-cert-20b0e0b9-7a4e-4c88-9dd3-7aae1201ac72.key
   sudo: yes
 
-- name: copy API cert.crt to the control node
+- name: copy plugin cert to agent node
   copy:
     src: "{{ flocker_local_tempdir }}/plugin-cert-20b0e0b9-7a4e-4c88-9dd3-7aae1201ac72.crt"
     dest: /etc/flocker/plugin.crt
@@ -14,10 +14,10 @@
   notify:
     - restart flocker-docker-plugin
 
-- name: copy API cert.key to the control node
+- name: copy plugin key to agent node
   copy:
     src: "{{ flocker_local_tempdir }}/plugin-cert-20b0e0b9-7a4e-4c88-9dd3-7aae1201ac72.key"
-    dest: /etc/flocker/{{ flocker_api_cert_name }}.key
+    dest: /etc/flocker/plugin.key
   sudo: yes
   notify:
     - restart flocker-docker-plugin


### PR DESCRIPTION
… to be copied for the plugin service to start; named configure_plugin tasks accordingly